### PR TITLE
Make all images responsive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1079,9 +1079,7 @@ figure {
   margin: 0; }
 
 img {
-  vertical-align: middle; }
-
-.img-responsive {
+  vertical-align: middle;
   display: block;
   max-width: 100%;
   height: auto; }


### PR DESCRIPTION
Currently on phones the images width mess with the layout. This makes
all images responsive by default.